### PR TITLE
Video position validation

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,4 +4,5 @@ class Video < ApplicationRecord
   has_many :user_videos
   has_many :users, through: :user_videos
   belongs_to :tutorial
+  validates_presence_of :position
 end

--- a/lib/tasks/video.rake
+++ b/lib/tasks/video.rake
@@ -1,0 +1,20 @@
+namespace :video do
+  desc "TODO"
+  task update_position_of_nil: :environment do
+    nil_videos = Video.where(position: nil)
+    count_nil_videos = nil_videos.count
+    if count_nil_videos > 0
+      nil_videos.each do |video|
+        tutorials_last_position = Video.where(tutorial_id: video.tutorial_id).where.not(position: nil).order(position: :DESC).limit(1).pluck(:position)[0]
+        if tutorials_last_position > 0 
+          video.update(position: (tutorials_last_position + 1))
+        else
+          video.update(position: 1)
+        end
+      end
+      puts "Updated #{count_nil_videos} Video's with nil position values"
+    else
+      puts "There are no Video's with nil position values"
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Video, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:position) }
+  end
+end


### PR DESCRIPTION
resolves #9

Adds validation of `position` on `Video` table and tests model.
Adds rake task of `rake video:update_position_of_nil` which will update all `videos` that have a `NULL` value with the next position based on the `tutorial_id`. 